### PR TITLE
unescape the path for public files

### DIFF
--- a/src/prax/middlewares/public_file_middleware.cr
+++ b/src/prax/middlewares/public_file_middleware.cr
@@ -36,7 +36,8 @@ module Prax
       def path(handler)
         public_path = handler.app.path.public_path
         uri = URI.parse(handler.request.uri)
-        File.join(public_path, uri.path.to_s)
+        path = URI.unescape(uri.path.to_s)
+        File.join(public_path, path)
       end
 
       def file?(file_path)


### PR DESCRIPTION
`uri.path.to_s` could be something like:

> "images/file%20with%20spaces.png"

while the file would be named:

> "public/images/file with spaces.png"
