### PR TITLE
Spawner show pass 127.0.0.1 instead of localhost to rackup

### DIFF
--- a/src/prax/application/spawner.cr
+++ b/src/prax/application/spawner.cr
@@ -77,7 +77,7 @@ module Prax
     private def spawn_rack_application
       cmd = [] of String
       cmd += ["bundle", "exec"] if path.gemfile?
-      cmd += ["rackup", "--host", "localhost", "--port", app.port.to_s]
+      cmd += ["rackup", "--host", "127.0.0.1", "--port", app.port.to_s]
       env = load_env
 
       File.open(path.log_path, "w") do |log|


### PR DESCRIPTION
localhost might not resolve to 127.0.0.1 espacialy if you have a ipv6 stack.

I found this issue as on my debian localhost resolve to both 127.0.0.1 and ::1. When I attempt to start a rails app with puma, puma binds to ::1 only and prax is never able to connect.


