### PR TITLE
Fix response headers

### DIFF
--- a/src/prax/parser/header.cr
+++ b/src/prax/parser/header.cr
@@ -31,7 +31,7 @@ module Prax
       end
 
       def to_s
-        "#{name}: #{values.join(", ")}"
+        values.map { |value| "#{name}: #{value}" }.join("\r\n")
       end
 
       def to_i


### PR DESCRIPTION
prevent multivalue headers to be combined (ie separated by comma). it causes big issues when the header value already contains a comma. This is very common for cookie with expires value.

The Cookie spec does claim that you can combine multiple cookies in one header the same way other headers can be combined (comma-separated), but it also points out that non-conforming syntaxes  are still common and must be dealt with by implementations.