### PR TITLE
add in support for .praxrc files (via a helper)

### DIFF
--- a/bin/prax-rc
+++ b/bin/prax-rc
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+. .praxrc
+
+exec "$@"

--- a/src/prax/application/path.cr
+++ b/src/prax/application/path.cr
@@ -20,6 +20,10 @@ module Prax
       File.exists?(gemfile_path)
     end
 
+    def praxrc?
+      File.exists?(praxrc_path)
+    end
+
     def forwarding?
       File.file?(@path) && port > 0
     end
@@ -52,6 +56,10 @@ module Prax
 
     def gemfile_path
       File.join(@path, "Gemfile")
+    end
+
+    def praxrc_path
+      File.join(@path, ".praxrc")
     end
 
     def rackup_path

--- a/src/prax/application/spawner.cr
+++ b/src/prax/application/spawner.cr
@@ -76,8 +76,10 @@ module Prax
 
     private def spawn_rack_application
       cmd = [] of String
+      cmd << File.join(ENV["PRAX_ROOT"],"bin", "prax-rc") if path.praxrc?
       cmd += ["bundle", "exec"] if path.gemfile?
       cmd += ["rackup", "--host", "localhost", "--port", app.port.to_s]
+
       env = load_env
 
       File.open(path.log_path, "w") do |log|

--- a/test/hosts/praxrc/.praxrc
+++ b/test/hosts/praxrc/.praxrc
@@ -1,0 +1,2 @@
+export PRAX_ENV_VAR=itworks
+

--- a/test/hosts/praxrc/config.ru
+++ b/test/hosts/praxrc/config.ru
@@ -1,0 +1,3 @@
+run(lambda do |env|
+  [200, {}, [ENV['PRAX_ENV_VAR']]]
+end)

--- a/test/praxrc_test.rb
+++ b/test/praxrc_test.rb
@@ -1,0 +1,8 @@
+require_relative "test_helper"
+
+class PraxrcTest < Minitest::Test
+  def test_praxrc_loaded
+    assert_equal "itworks", Net::HTTP.get(URI("http://praxrc.dev:20557/"))
+    assert_equal "itworks", Net::HTTP.get(URI("http://praxrc.127.0.0.1.xip.io:20557/"))
+  end
+end


### PR DESCRIPTION
Specifying RVM setup in the ~/.praxconfig does not work, as it checks and configures RVM from where you start prax.. NOT where the application is started..  Further that page documents that prax looks at myapp/.praxrc, however it does not do that.  

This PR adds in proper support for .praxrc (via a helper).  Thus in my ruby apps I can create a .praxrc that has the following
```
rvm rvmrc load
```
