### PR TITLE
fix forwarding of headers.

### DIFF
--- a/src/prax/parser/header.cr
+++ b/src/prax/parser/header.cr
@@ -31,7 +31,9 @@ module Prax
       end
 
       def to_s
-        "#{name}: #{values.join(", ")}"
+        values.map {|value|
+          "#{name}: #{value}"
+        }.join("\r\n")
       end
 
       def to_i

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -31,7 +31,7 @@ class ProxyTest < Minitest::Test
 
   def test_returns_multiple_set_cookie_headers
     response = Net::HTTP.get_response(URI("http://cookies.dev:20557/"))
-    assert_equal ["first=123, second=456"], response.get_fields("Set-Cookie")
+    assert_equal ["first=123", "second=456"], response.get_fields("Set-Cookie")
   end
 
   def test_supports_bundler_with_special_gems


### PR DESCRIPTION
This adjusts how headers are combined together..  as joining the values by "," for cookies does not actually work correctly.. (headers are not set).

This rebuilds the headers back the way they were originally as separate entries.