### PR TITLE
prax-iptables: allow systemd >= 197 interface names

### DIFF
--- a/libexec/prax-iptables
+++ b/libexec/prax-iptables
@@ -5,7 +5,7 @@ set -e
 
 HTTP_PORT=20559
 HTTPS_PORT=20558
-DEVICES=$(ls /sys/class/net | egrep '^(wlan|eth)[0-9]+')
+DEVICES=$(ls /sys/class/net | egrep '^(eth|en|wl|sl|ww)')
 
 case "$1" in
   start)


### PR DESCRIPTION
systemd >= 197 uses a different ifname scheme, so the change in 3ece05d01fd9591ec2b2ec93a14dcca7fec5f3d4 breaks Prax for me on a relatively standard setup (Ubuntu 16.04 LTS). My interfaces are `wlp3s0` and `enp0s25`.

This PR relaxes the regex to allow the new interface names as documented below.

See:
- https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
- https://github.com/systemd/systemd/blob/c7458f93991105e9890b0ec8dfc849b019b5df5f/src/udev/udev-builtin-net_id.c#L20
