### PR TITLE
recognize new interface naming scheme as well

### DIFF
--- a/libexec/prax-iptables
+++ b/libexec/prax-iptables
@@ -5,7 +5,7 @@ set -e
 
 HTTP_PORT=20559
 HTTPS_PORT=20558
-DEVICES=$(ls /sys/class/net | egrep '^(wlan|eth)[0-9]+')
+DEVICES=$(ls /sys/class/net | egrep '^(wlan|eth|(wl|en)p)[0-9]+')
 
 case "$1" in
   start)


### PR DESCRIPTION
Up to date linux systems may have [a different naming scheme for interfaces](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/) which is why my wifi adapter wasn't recognized (`wlp2s0`).

I updated the regular expression so it should work with both naming schemes.

Thank you for prax and have a nice day!