### PR TITLE
recognize new interface naming scheme as well

### DIFF
--- a/libexec/prax-iptables
+++ b/libexec/prax-iptables
@@ -5,7 +5,7 @@ set -e
 
 HTTP_PORT=20559
 HTTPS_PORT=20558
-DEVICES=$(ls /sys/class/net | egrep '^(wlan|eth)[0-9]+')
+DEVICES=$(ls -l /sys/class/net/ | grep -v virtual | sed -n 's/.* \(\w*\) -> .*/\1/p')
 
 case "$1" in
   start)


### PR DESCRIPTION
This PR _could_ help to solve the issue that

> [we need a better mechanism to detect real devices, leaving virtual ones alone](https://github.com/ysbaddaden/prax.cr/pull/33#issuecomment-254352070)

However, I don't know whether this is generic enough because it relies on `/sys/class/net/` and `ls` having the format `interface -> ...`.

Besides from that it's pretty generic and should work even **if** you have a virtual devices named like a physical one.
