### PR TITLE
Add support for empty header values

### DIFF
--- a/src/prax/parser.cr
+++ b/src/prax/parser.cr
@@ -5,7 +5,7 @@ module Prax
   class Parser
     REQUEST_LINE_RE = /\A([A-Z]+)[ \t]+(.+?)[ \t]+(HTTP\/[\d.]+)\Z/
     STATUS_LINE_RE = /\A(HTTP\/[\d.]+)[ \t]+(\d+)[ \t]+(.+?)\Z/
-    HEADER_RE = /([^:]+):\s+(.+)/
+    HEADER_RE = /([^:]+):(?:\s+(.+))?/
 
     class InvalidRequest < Exception; end
 
@@ -41,7 +41,10 @@ module Prax
         break if (line = @socket.read_line.chomp).empty?
 
         if match = HEADER_RE.match(line)
-          object.add_header(match[1], match[2])
+          name = match[1]
+          # permit empty header values
+          value = match[2]? || ""
+          object.add_header(name, value)
         else
           raise InvalidRequest.new("invalid header: '#{line}'")
         end

--- a/test/hosts/empty-header/config.ru
+++ b/test/hosts/empty-header/config.ru
@@ -1,0 +1,3 @@
+run(lambda do |env|
+  [200, { "Access-Control-Expose-Headers" => "" }, ["an empty header is tolerated"]]
+end)

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -62,4 +62,10 @@ class ProxyTest < Minitest::Test
       assert_equal "::1, 10.0.3.1", headers["HTTP_X_FORWARDED_SERVER"]
     end
   end
+
+  def test_empty_header
+    response = Net::HTTP.get_response(URI("http://empty-header.dev:20557/"))
+    assert_equal "", response["Access-Control-Expose-Headers"]
+    assert_equal "an empty header is tolerated", response.body
+  end
 end


### PR DESCRIPTION
Some servers might return empty HTTP header values.  For example:

```
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, PATCH
Access-Control-Expose-Headers:
Access-Control-Max-Age: 1728000
```

This allows for headers to have blank values.

Please feel free to rewrite this if there is a cleaner way of doing it. I'm brand-new to Crystal. I tried checking `match.size()`, but it was always `3`, and `match[3]` and `match[3].nil?` always raised some sort of array bounds error when there was no header value.
