### PR TITLE
Make page wider so backtrace becomes readable

### DIFF
--- a/src/prax/templates/layout.ecr
+++ b/src/prax/templates/layout.ecr
@@ -21,7 +21,7 @@
    a { color: #776; }
 
    .page {
-     max-width: 480px;
+     max-width: 68em;
      margin: 36px auto;
      padding: 36px 90px;
      background: #fff;
@@ -68,6 +68,7 @@
      background: #2a2a29;
      color: #eee;
      padding: 1em;
+     overflow-x: auto;
    }
    pre span {
      color: #aa9;


### PR DESCRIPTION
I also added overflow-x: auto to the pre element so that its contents
won't spill out anymore. If some text was too wide it would leave a
ghostly impression to the right of the pre element.