### PR TITLE
Fix failing tests.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,7 @@ GEM
       json (>= 1.7.7)
     json (2.0.3)
     minitest (5.5.1)
-    puma (2.11.0)
-      rack (>= 1.1, < 2.0)
+    puma (3.11.0)
     rack (1.6.0)
     rake (10.4.2)
 
@@ -35,4 +34,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.6
+   1.16.0

--- a/test/failures_test.rb
+++ b/test/failures_test.rb
@@ -21,9 +21,7 @@ class FailuresTest < Minitest::Test
 
   def test_host_header_is_missing_but_found_in_uri
     TCPSocket.open("localhost", 20557) do |socket|
-      # The empty query string is a workaround for the bug fixed here:
-      # https://github.com/puma/puma/pull/1259
-      socket.write("GET http://example.dev:20557/? HTTP/1.1\r\n\r\n")
+      socket.write("GET http://example.dev:20557/ HTTP/1.1\r\n\r\n")
       assert_equal "HTTP/1.1 200 OK\r\n", socket.gets
     end
   end

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -61,9 +61,6 @@ class ProxyTest < Minitest::Test
   end
 
   def test_empty_header
-    # We can stop skipping this test once this fix is released:
-    # https://github.com/puma/puma/pull/1261
-    skip "Puma won't send an empty http header value"
     response = Net::HTTP.get_response(URI("http://empty-header.dev:20557/"))
     assert_equal "", response["Access-Control-Expose-Headers"]
     assert_equal "an empty header is tolerated", response.body


### PR DESCRIPTION
Fixes https://github.com/ysbaddaden/prax.cr/issues/63 with a single conservative update instead of updating everything like we did in https://github.com/ysbaddaden/prax.cr/pull/50.

I tested with Ruby 2.3.3.  Let me know if there are any other Rubies this needs to work on.