### PR TITLE
Look up headers case-insensitively / allow requests with lowercase headers.

### DIFF
--- a/src/prax/parser/common.cr
+++ b/src/prax/parser/common.cr
@@ -12,7 +12,7 @@ module Prax
       end
 
       def header(name)
-        headers.find { |header| header.name == name }
+        headers.find { |header| header.name.downcase == name.downcase }
       end
 
       def content_length

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -68,4 +68,11 @@ class ProxyTest < Minitest::Test
     assert_equal "", response["Access-Control-Expose-Headers"]
     assert_equal "an empty header is tolerated", response.body
   end
+
+  def test_lowercase_header
+    TCPSocket.open("localhost", 20557) do |socket|
+      socket.write("GET / HTTP/1.1\r\nhost: example.dev\r\n\r\n")
+      assert_equal "HTTP/1.1 200 OK\r\n", socket.gets # a lowercase request header is tolerated
+    end
+  end
 end


### PR DESCRIPTION
Requests with the user-agent "Brightcove BANSHI" from zencoder.com have headers with lowercase names, which caused the error "missing host header" when parsing the lowercase "host" header from them.

HTTP headers names are case-insensitive per the spec so this is how they should be looked-up.