### PR TITLE
Fix debian compilation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,9 @@ all: $(SOURCES)
 	mkdir -p bin
 	$(CRYSTAL_BIN) build $(CURDIR)/src/prax.cr -o bin/prax-binary
 
-# --no-debug below is a workaround for this issue: https://github.com/crystal-lang/crystal/issues/4719
 release: $(SOURCES)
 	mkdir -p $(BINDIR)
-	$(CRYSTAL_BIN) build --release $(CURDIR)/src/prax.cr -o $(BINDIR)/prax-binary --no-debug
+	$(CRYSTAL_BIN) build --release $(CURDIR)/src/prax.cr -o $(BINDIR)/prax-binary
 	#strip --strip-uneeded $(BINDIR)/prax-binary
 
 run: all

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ all: $(SOURCES)
 	mkdir -p bin
 	$(CRYSTAL_BIN) build $(CURDIR)/src/prax.cr -o bin/prax-binary
 
+# --no-debug below is a workaround for this issue: https://github.com/crystal-lang/crystal/issues/4719
 release: $(SOURCES)
 	mkdir -p $(BINDIR)
-	$(CRYSTAL_BIN) build --release $(CURDIR)/src/prax.cr -o $(BINDIR)/prax-binary
+	$(CRYSTAL_BIN) build --release $(CURDIR)/src/prax.cr -o $(BINDIR)/prax-binary --no-debug
 	#strip --strip-uneeded $(BINDIR)/prax-binary
 
 run: all

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCDIR = $(PREFIX)/opt/prax/doc
 VERSION = `cat ../VERSION`
 
 #DEB_DEPENDENCIES = "-d 'libpcre3' -d 'libgc1c2' -d 'libunwind8 | libunwind7'"
-DEB_DEPENDENCIES = "-d 'libssl1.0.0'"
+DEB_DEPENDENCIES = "-d 'libssl1.0.0 | libssl1.1'"
 
 SOURCES = $(wildcard src/*.cr) $(wildcard src/**/*.cr)
 


### PR DESCRIPTION
Fixes https://github.com/ysbaddaden/prax.cr/issues/65 by updating the Makefile so it can create a usable ".deb" for Debian 9 without resorting to old packages on that distro.