### PR TITLE
Update to new File.info API.

### DIFF
--- a/src/prax/application.cr
+++ b/src/prax/application.cr
@@ -48,7 +48,7 @@ module Prax
       end
 
       if path.restart? && (started_at = spawner.started_at)
-        return started_at.epoch < File::Stat.new(path.restart_path).mtime.epoch
+        return started_at.epoch < File.info(path.restart_path).modification_time.epoch
       end
 
       false

--- a/src/prax/middlewares/public_file_middleware.cr
+++ b/src/prax/middlewares/public_file_middleware.cr
@@ -14,12 +14,12 @@ module Prax
 
         if file?(file_path)
           Prax.logger.debug { "serving '#{file_path}'" }
-          stat = File::Stat.new(file_path)
+          info = File.info(file_path)
           type = MIME_TYPES.fetch(File.extname(file_path).downcase, DEFAULT_MIME_TYPE)
 
           headers = [] of String
           headers << "Content-Type: #{type}"
-          headers << "Content-Length: #{stat.size}"
+          headers << "Content-Length: #{info.size}"
 
           handler.reply(200, headers) do
             stream_file(handler.client, file_path)


### PR DESCRIPTION
Seems like `File::Stat` was removed and replaced with `File.info` in Crystal 0.25.0.

Ensure the project still compiles on the latest Crystal.