### PR TITLE
Fix 0.27.0 breaking changes

### DIFF
--- a/src/prax/application.cr
+++ b/src/prax/application.cr
@@ -48,7 +48,7 @@ module Prax
       end
 
       if path.restart? && (started_at = spawner.started_at)
-        return started_at.epoch < File.info(path.restart_path).modification_time.epoch
+        return started_at.to_unix < File.info(path.restart_path).modification_time.to_unix
       end
 
       false

--- a/src/prax/handler.cr
+++ b/src/prax/handler.cr
@@ -67,7 +67,7 @@ module Prax
     end
 
     def reply(code, body = nil)
-      status = STATUSES.fetch(code)
+      status = STATUSES[code]
       body = body ? body + "\n" : ""
 
       client << "#{request.http_version} #{code} #{status}\r\n"
@@ -79,7 +79,7 @@ module Prax
     end
 
     def reply(code, headers = nil)
-      status = STATUSES.fetch(code)
+      status = STATUSES[code]
 
       headers ||= [] of String
       headers << "Connection: close"


### PR DESCRIPTION
Looks like Crystal renamed a few methods in 0.27.0.  I had to make these changes before I could compile Prax again.