### PR TITLE
Ensures a rack application started by prax is accessible through 127.0.0.1 even on IPV6 systems

### DIFF
--- a/src/prax/application/spawner.cr
+++ b/src/prax/application/spawner.cr
@@ -78,7 +78,7 @@ module Prax
       cmd = [] of String
       cmd << File.join(ENV["PRAX_ROOT"],"bin", "prax-rc") if path.praxrc?
       cmd += ["bundle", "exec"] if path.gemfile?
-      cmd += ["rackup", "--host", "localhost", "--port", app.port.to_s]
+      cmd += ["rackup", "--host", "127.0.0.1", "--port", app.port.to_s]
 
       File.open(path.log_path, "w") do |log|
         @process = Process.new(cmd.first, cmd[1 .. -1], output: log, error: log, chdir: path.to_s)


### PR DESCRIPTION
Previously to this commit, the underlying command used to start a rack application was something like this:

`$HOME/.rvm/gems/<ruby version>/bin/rackup --host localhost --port <port>`

The issue is that on systems with IPV6 enabled by default like on Fedora 29, the OS will be responsible to translate `localhost` into its actual IP address, which will be `::1`, leaving the application accessible on `localhost:<port>` but not on `127.0.0.1:<port>`, as it is expected to be in order to check if it is connectable yet here:

https://github.com/ysbaddaden/prax.cr/blob/78a7926b29159e930406b23d2cea75bcbc86a0d6/src/prax/application.cr#L66

Given the above TCP connection will never succeed, prax will eventually error saying the application startup timed out.

This commit simply ensures that the rack application is started at the exact host it will be queried on later for readiness.