### PR TITLE
Adds an option to disable monitoring.

### DIFF
--- a/src/prax.cr
+++ b/src/prax.cr
@@ -20,7 +20,7 @@ module Prax
   end
 
   def self.start
-    Monitor.start
+    Monitor.start unless Prax.no_monitor
     server.run(http_port, https_port)
   end
 
@@ -85,6 +85,10 @@ OptionParser.parse! do |opts|
 
   opts.on("-t", "--timeout WAIT", "Set timeout to load app") do |wait|
     Prax.timeout = wait.to_i
+  end
+
+  opts.on("--disable-monitor", "Disable monitoring") do
+    Prax.no_monitor = true
   end
 
   opts.on("-h", "--help", "Show help") do

--- a/src/prax/config.cr
+++ b/src/prax/config.cr
@@ -57,6 +57,14 @@ module Prax
     @@timeout = wait
   end
 
+  def self.no_monitor
+    @@no_monitor ||= false
+  end
+
+  def self.no_monitor=(no_monitor : Bool)
+    @@no_monitor = no_monitor
+  end
+
   def self.root_path
     ENV["PRAX_ROOT"]
   end


### PR DESCRIPTION
So that apps with heavy startup process don't get killed every 10min one goes for a coffee.

It keeps the monitor enabled by default though.