### PR TITLE
Require libssl1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCDIR = $(PREFIX)/opt/prax/doc
 VERSION = `cat ../VERSION`
 
 #DEB_DEPENDENCIES = "-d 'libpcre3' -d 'libgc1c2' -d 'libunwind8 | libunwind7'"
-DEB_DEPENDENCIES = "-d 'libssl1.0.2 | libssl1.0.0'"
+DEB_DEPENDENCIES = "-d 'libssl1.1'"
 
 SOURCES = $(wildcard src/*.cr) $(wildcard src/**/*.cr)
 


### PR DESCRIPTION
Like in https://github.com/ysbaddaden/prax.cr/pull/70, I found I was unable to install the .deb in Debian 10 without making this change.

libssl1.0 is no longer available in Debian 10, but 1.1 is, as well as in Ubuntu 18.

What do you think about moving forward with this version?