### PR TITLE
Replace defunct xip.io with nip.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Prax proposes 2 solutions to resolve `.test` and `.localhost` domains:
 - an obsolete and deprecated NSSwitch extension, only compatible wih glibc
   and no longer compatible with Google Chrome/Chromium, and certainly more.
 
-### xip.io
+### nip.io
 
-Prax supports http://xip.io/ domains, so you can use `myapp.129.168.0.1.xip.io`
+Prax supports http://nip.io/ domains, so you can use `myapp.129.168.0.1.nip.io`
 for example. This is useful when using an external device like a smartphone,
 tablet or another computer to test your websites on.
 
@@ -77,7 +77,7 @@ $ sudo service dnsmasq restart
 The port redirections are iptables rules, that are installed and removed using
 an initd script. The script redirects the port :80 and :443 on 127.0.0.1 and for
 each `wlanX` and `ethX` devices found on your machine, to allow incoming
-traffic, so you can use http://xip.io to test on external devices, as mentioned
+traffic, so you can use http://nip.io to test on external devices, as mentioned
 above.
 
 You can install or remove the redirections with:

--- a/src/prax/application.cr
+++ b/src/prax/application.cr
@@ -3,7 +3,7 @@ require "./application/finders"
 require "./application/spawner"
 
 module Prax
-  XIP_IO = /\A(.+)\.(?:\d+\.){4}xip\.io\Z/
+  NIP_IO = /\A(.+)\.(?:\d+\.){4}nip\.io\Z/
 
   class Application
     getter name : String

--- a/src/prax/application/finders.cr
+++ b/src/prax/application/finders.cr
@@ -29,7 +29,7 @@ module Prax
     end
 
     private def self.search(host)
-      if m = XIP_IO.match(host)
+      if m = NIP_IO.match(host)
         host = m[1] + ".test"
       end
       names = host.split('.').tap(&.pop)

--- a/test/praxrc_test.rb
+++ b/test/praxrc_test.rb
@@ -3,6 +3,6 @@ require_relative "test_helper"
 class PraxrcTest < Minitest::Test
   def test_praxrc_loaded
     assert_equal "itworks", Net::HTTP.get(URI("http://praxrc.localhost:20557/"))
-    assert_equal "itworks", Net::HTTP.get(URI("http://praxrc.127.0.0.1.xip.io:20557/"))
+    assert_equal "itworks", Net::HTTP.get(URI("http://praxrc.127.0.0.1.nip.io:20557/"))
   end
 end

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -18,12 +18,12 @@ class ProxyTest < Minitest::Test
   end
 
   # This test may fail randomly.  You may have better success using OpenDNS.
-  def test_supports_xip_io
-    assert_equal "example", Net::HTTP.get(URI("http://example.127.0.0.1.xip.io:20557/"))
-    assert_equal "example", Net::HTTP.get(URI("http://w1.example.127.0.0.1.xip.io:20557/"))
+  def test_supports_nip_io
+    assert_equal "example", Net::HTTP.get(URI("http://example.127.0.0.1.nip.io:20557/"))
+    assert_equal "example", Net::HTTP.get(URI("http://w1.example.127.0.0.1.nip.io:20557/"))
 
-    assert_equal "app1.example", Net::HTTP.get(URI("http://app1.example.127.0.0.1.xip.io:20557/"))
-    assert_equal "app2.example", Net::HTTP.get(URI("http://w3.app2.example.127.0.0.1.xip.io:20557/"))
+    assert_equal "app1.example", Net::HTTP.get(URI("http://app1.example.127.0.0.1.nip.io:20557/"))
+    :ssert_equal "app2.example", Net::HTTP.get(URI("http://w3.app2.example.127.0.0.1.nip.io:20557/"))
   end
 
   def test_returns_multiple_set_cookie_headers

--- a/test/public_file_test.rb
+++ b/test/public_file_test.rb
@@ -3,7 +3,7 @@ require_relative "test_helper"
 class PublicFileTest < Minitest::Test
   def test_serves_files_in_public_folder
     assert_equal "my file contents\n", Net::HTTP.get(URI("http://example.localhost:20557/file.txt"))
-    assert_equal "my file contents\n", Net::HTTP.get(URI("http://example.127.0.0.1.xip.io:20557/file.txt"))
+    assert_equal "my file contents\n", Net::HTTP.get(URI("http://example.127.0.0.1.nip.io:20557/file.txt"))
   end
 
   def test_serves_files_for_non_rack_application


### PR DESCRIPTION
xip.io is dead, nip.io does the same thing